### PR TITLE
Allow placeholders in component names

### DIFF
--- a/grafana_dashboards/components/base.py
+++ b/grafana_dashboards/components/base.py
@@ -155,13 +155,17 @@ class JsonListGenerator(JsonGenerator):
         result_list = []
         for items in data:
             if isinstance(items, str):
+                # this is component without context
                 result_list += self.registry.get_component(type(self), items).gen_json()
             else:
+                # TODO add check for dictionary
                 for (item_type, item_data) in items.iteritems():
                     if item_type not in self.component_item_types:
+                        # this is named component with context
                         for context in Context.create_context(item_data, get_placeholders(item_type)):
                             result_list += self.registry.get_component(type(self), item_type).gen_json(context)
                     else:
+                        # this is inplace defined component
                         item = self.registry.create_component(item_type, {item_type: item_data}).gen_json()
                         if isinstance(item, list):
                             result_list += item

--- a/grafana_dashboards/components/projects.py
+++ b/grafana_dashboards/components/projects.py
@@ -12,9 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import string
-
-from grafana_dashboards.components.base import ComponentBase
+from grafana_dashboards.components.base import ComponentBase, get_placeholders
 from grafana_dashboards.components.dashboards import Dashboard
 from grafana_dashboards.context import Context
 
@@ -25,7 +23,7 @@ class Project(ComponentBase):
     def __init__(self, data, registry):
         super(Project, self).__init__(data, registry)
         self._placeholders = [placeholder for dashboard in self._get_dashboard_names()
-                              for placeholder in Project._get_placeholders(dashboard)]
+                              for placeholder in get_placeholders(dashboard)]
 
     def _get_dashboard_names(self):
         return self.data.get('dashboards', [])
@@ -33,10 +31,6 @@ class Project(ComponentBase):
     def get_dashboards(self):
         return [self.registry.get_component(Dashboard, dashboard_name) for dashboard_name in
                 self._get_dashboard_names()]
-
-    @staticmethod
-    def _get_placeholders(s):
-        return [v[1] for v in string.Formatter().parse(s) if v[1]]
 
     def get_contexts(self):
         return Context.create_context(self.data, self._placeholders)

--- a/grafana_dashboards/errors.py
+++ b/grafana_dashboards/errors.py
@@ -28,9 +28,5 @@ class WrongComponentAttributeCountError(DashboardBuilderException):
     pass
 
 
-class MissingComponentNameError(DashboardBuilderException):
-    pass
-
-
 class UnregisteredComponentError(DashboardBuilderException):
     pass

--- a/samples/project.yaml
+++ b/samples/project.yaml
@@ -94,12 +94,21 @@
               metric-prefix: '{metric-prefix}'
               component: '{component}'
     - second-row
+    - '{param}-row':
+        param:
+          - value1
+          - value2
 
 - name: second-row
   rows:
     - row:
         title: Placeholder row
         height: 100px
+
+- name: '{param}-row'
+  rows:
+    - row:
+        title: '{param} row'
 
 - name: connections
   panels:

--- a/tests/grafana_dashboards/components/dashboard/referenced_rows.json
+++ b/tests/grafana_dashboards/components/dashboard/referenced_rows.json
@@ -15,6 +15,10 @@
     "mocked1",
     "mocked2",
     "mocked1",
+    "mocked2",
+    "mocked1",
+    "mocked2",
+    "mocked1",
     "mocked2"
   ],
   "templating": {

--- a/tests/grafana_dashboards/components/dashboard/referenced_rows.yaml
+++ b/tests/grafana_dashboards/components/dashboard/referenced_rows.yaml
@@ -11,3 +11,7 @@ dashboard:
     - row-defined-elsewhere
     - row-with-params:
         param1: 1
+    - row-with-{placeholder}:
+        placeholder:
+         - 1
+         - 2

--- a/tests/grafana_dashboards/components/panels/reference.json
+++ b/tests/grafana_dashboards/components/panels/reference.json
@@ -2,5 +2,9 @@
   "mocked1",
   "mocked2",
   "mocked1",
+  "mocked2",
+  "mocked1",
+  "mocked2",
+  "mocked1",
   "mocked2"
 ]

--- a/tests/grafana_dashboards/components/panels/reference.yaml
+++ b/tests/grafana_dashboards/components/panels/reference.yaml
@@ -2,3 +2,7 @@ panels:
   - graph-defined-elsewhere
   - graph-with-params:
       param1: 1
+  - graph-with-{placeholder}:
+      placeholder:
+        - 1
+        - 2

--- a/tests/grafana_dashboards/components/rows/reference.json
+++ b/tests/grafana_dashboards/components/rows/reference.json
@@ -2,5 +2,9 @@
   "mocked1",
   "mocked2",
   "mocked1",
+  "mocked2",
+  "mocked1",
+  "mocked2",
+  "mocked1",
   "mocked2"
 ]

--- a/tests/grafana_dashboards/components/rows/reference.yaml
+++ b/tests/grafana_dashboards/components/rows/reference.yaml
@@ -2,3 +2,7 @@ rows:
   - row-defined-elsewhere
   - row-with-params:
       param1: 1
+  - row-with-{placeholder}:
+      placeholder:
+        - 1
+        - 2

--- a/tests/grafana_dashboards/components/templates/reference.json
+++ b/tests/grafana_dashboards/components/templates/reference.json
@@ -2,5 +2,9 @@
   "mocked1",
   "mocked2",
   "mocked1",
+  "mocked2",
+  "mocked1",
+  "mocked2",
+  "mocked1",
   "mocked2"
 ]

--- a/tests/grafana_dashboards/components/templates/reference.yaml
+++ b/tests/grafana_dashboards/components/templates/reference.yaml
@@ -2,3 +2,7 @@ templates:
   - query-defined-elsewhere
   - query-with-params:
       param1: 1
+  - query-with-{placeholder}:
+      placeholder:
+        - 1
+        - 2


### PR DESCRIPTION
This change allows user to create component templates and create multiple instances solely based on configuration.