### PR TITLE
Add 'rightSide' property to graph legend

### DIFF
--- a/grafana_dashboards/components/panels.py
+++ b/grafana_dashboards/components/panels.py
@@ -72,6 +72,7 @@ class Graph(PanelsItemBase):
                 'total': self.data['legend'].get('total', False),
                 'avg': self.data['legend'].get('avg', False),
                 'alignAsTable': self.data['legend'].get('alignAsTable', False),
+                'rightSide': self.data['legend'].get('rightSide', False),
                 'hideEmpty': self.data['legend'].get('hideEmpty', False)
             }
         if 'tooltip' in self.data:

--- a/tests/grafana_dashboards/components/graph/full.json
+++ b/tests/grafana_dashboards/components/graph/full.json
@@ -48,6 +48,7 @@
     "total": true,
     "values": true,
     "alignAsTable": true,
+    "rightSide": true,
     "hideEmpty": true
   },
   "tooltip": {

--- a/tests/grafana_dashboards/components/graph/full.yaml
+++ b/tests/grafana_dashboards/components/graph/full.yaml
@@ -49,6 +49,7 @@ graph:
     total: true
     avg: true
     alignAsTable: true
+    rightSide: true
     hideEmpty: true
   tooltip:
     value_type: cumulative


### PR DESCRIPTION
This little pr adds 'rightSide' property to legend for graph panel