### PR TITLE
Add folder id at dashboard level.

### DIFF
--- a/grafana_dashboards/client/grafana.py
+++ b/grafana_dashboards/client/grafana.py
@@ -45,5 +45,9 @@ class GrafanaExporter(DashboardExporter):
     def process_dashboard(self, project_name, dashboard_name, dashboard_data):
         super(GrafanaExporter, self).process_dashboard(project_name, dashboard_name, dashboard_data)
         body = {'overwrite': True, 'dashboard': dashboard_data}
+
+        if 'folderId' in dashboard_data:
+            body.update({'folderId': dashboard_data['folderId']})
+
         logger.info("Uploading dashboard '%s' to %s", dashboard_name, self._host)
         self._connection.make_request('/api/dashboards/db', body)

--- a/grafana_dashboards/components/dashboards.py
+++ b/grafana_dashboards/components/dashboards.py
@@ -52,6 +52,8 @@ class Dashboard(JsonGenerator):
             nav['refresh_intervals'] = data.get('refresh_intervals', [])
         if 'refresh' in data:
             json_data['refresh'] = data.get('refresh')
+        if 'folderId' in data:
+            json_data['folderId'] = data.get('folderId')
         if get_component_type(Annotations) in data:
             json_data['annotations'] = {'list': self.registry.create_component(Annotations, data).gen_json()}
         if get_component_type(Rows) in data:


### PR DESCRIPTION
This PR adds the `folder_id` field in the YAML of a dashboard definition. 

The field allows to specify, at dashboard level, a folder id where the dashboard has to be uploaded to. 
Below an example of a YAML file: 
```yaml
- name: Dashboard
  dashboard:
    folder_id: 866
    title: 'A Dashboard'
```

resolves #156 