### PR TITLE
Specify Loader= argument for each yams.load() functions

### DIFF
--- a/grafana_dashboards/cli.py
+++ b/grafana_dashboards/cli.py
@@ -95,7 +95,7 @@ def main():
                                                 config)
 
     context = config.get_config('context')
-    context.update(yaml.load(args.context))
+    context.update(yaml.load(args.context, Loader=yaml.FullLoader))
 
     projects = DefinitionParser().load_projects(paths)
     project_processor = ProjectProcessor(dashboard_exporters)

--- a/grafana_dashboards/config.py
+++ b/grafana_dashboards/config.py
@@ -34,7 +34,7 @@ class Config(object):
             self._config = {}
         else:
             with open(config) as fp:
-                self._config = yaml.load(fp)
+                self._config = yaml.load(fp, Loader=yaml.FullLoader)
 
     def get_config(self, section):
         return self._config.setdefault(section, {})

--- a/grafana_dashboards/parser.py
+++ b/grafana_dashboards/parser.py
@@ -30,7 +30,7 @@ class DefinitionParser(object):
         registry = ComponentRegistry()
         for path in paths:
             with open(path, 'r') as fp:
-                for component in self._iter_over_all(yaml.load_all(fp)):
+                for component in self._iter_over_all(yaml.load_all(fp, Loader=yaml.FullLoader)):
                     registry.add(component)
         return registry[Project]
 

--- a/tests/grafana_dashboards/components/test_components.py
+++ b/tests/grafana_dashboards/components/test_components.py
@@ -49,7 +49,7 @@ def load_test_fixtures():
                 continue
             filename = f[:-5]
             with open(os.path.join(dirname, '%s.yaml' % filename), 'r') as fp:
-                config = yaml.load(fp)
+                config = yaml.load(fp, Loader=yaml.FullLoader)
             with open(os.path.join(dirname, '%s.json' % filename), 'r') as fp:
                 output = json.load(fp)
             yield component, filename, config, output


### PR DESCRIPTION
This PR removes the warning message related to the deprecation of the plain `yaml.load(input)` function. `Loader=` argument has been added in each point of the code which triggered the warning. 

Resolves #143.