### PR TITLE
Support sort ordering

### DIFF
--- a/grafana_dashboards/cli.py
+++ b/grafana_dashboards/cli.py
@@ -95,7 +95,7 @@ def main():
                                                 config)
 
     context = config.get_config('context')
-    context.update(yaml.load(args.context))
+    context.update(yaml.load(args.context, Loader=yaml.FullLoader))
 
     projects = DefinitionParser().load_projects(paths)
     project_processor = ProjectProcessor(dashboard_exporters)

--- a/grafana_dashboards/client/grafana.py
+++ b/grafana_dashboards/client/grafana.py
@@ -45,5 +45,9 @@ class GrafanaExporter(DashboardExporter):
     def process_dashboard(self, project_name, dashboard_name, dashboard_data):
         super(GrafanaExporter, self).process_dashboard(project_name, dashboard_name, dashboard_data)
         body = {'overwrite': True, 'dashboard': dashboard_data}
+
+        if 'folderId' in dashboard_data:
+            body.update({'folderId': dashboard_data['folderId']})
+
         logger.info("Uploading dashboard '%s' to %s", dashboard_name, self._host)
         self._connection.make_request('/api/dashboards/db', body)

--- a/grafana_dashboards/components/dashboards.py
+++ b/grafana_dashboards/components/dashboards.py
@@ -52,6 +52,8 @@ class Dashboard(JsonGenerator):
             nav['refresh_intervals'] = data.get('refresh_intervals', [])
         if 'refresh' in data:
             json_data['refresh'] = data.get('refresh')
+        if 'folderId' in data:
+            json_data['folderId'] = data.get('folderId')
         if get_component_type(Annotations) in data:
             json_data['annotations'] = {'list': self.registry.create_component(Annotations, data).gen_json()}
         if get_component_type(Rows) in data:

--- a/grafana_dashboards/components/panels.py
+++ b/grafana_dashboards/components/panels.py
@@ -36,7 +36,7 @@ class Graph(PanelsItemBase):
 
     _copy_fields = {'stack', 'fill', 'aliasColors', 'leftYAxisLabel', 'bars', 'lines', 'linewidth', 'y_formats',
                     'x-axis', 'y-axis', 'points', 'pointradius', 'percentage', 'steppedLine', 'repeat',
-                    'minSpan', 'datasource'}
+                    'repeatDirection', 'decimals', 'minSpan', 'datasource', 'description'}
 
     def gen_json_from_data(self, data, context):
         panel_json = super(Graph, self).gen_json_from_data(data, context)
@@ -72,6 +72,7 @@ class Graph(PanelsItemBase):
                 'total': self.data['legend'].get('total', False),
                 'avg': self.data['legend'].get('avg', False),
                 'alignAsTable': self.data['legend'].get('alignAsTable', False),
+                'rightSide': self.data['legend'].get('rightSide', False),
                 'hideEmpty': self.data['legend'].get('hideEmpty', False)
             }
         if 'tooltip' in self.data:
@@ -103,10 +104,9 @@ class Graph(PanelsItemBase):
 
 class SingleStat(PanelsItemBase):
 
-    # noinspection PySetFunctionToLiteral
-    _copy_fields = set(['prefix', 'postfix', 'nullText', 'format', 'thresholds', 'colorValue', 'colorBackground',
-                        'colors', 'prefixFontSize', 'valueFontSize', 'postfixFontSize', 'maxDataPoints', 'datasource',
-                        'repeat', 'decimals', 'minSpan'])
+    _copy_fields = {'prefix', 'postfix', 'nullText', 'format', 'thresholds', 'colorValue', 'colorBackground',
+                    'colors', 'prefixFontSize', 'valueFontSize', 'postfixFontSize', 'maxDataPoints', 'datasource',
+                    'repeat', 'repeatDirection', 'decimals', 'minSpan', 'description', 'colorPostfix'}
 
     def gen_json_from_data(self, data, context):
         panel_json = super(SingleStat, self).gen_json_from_data(data, context)
@@ -149,7 +149,7 @@ class SingleStat(PanelsItemBase):
 
 class Table(PanelsItemBase):
     # noinspection PySetFunctionToLiteral
-    _copy_fields = set(['fontSize', 'pageSize', 'showHeader', 'scroll', 'datasource'])
+    _copy_fields = {'fontSize', 'pageSize', 'showHeader', 'scroll', 'datasource', 'description'}
 
     def gen_json_from_data(self, data, context):
         panel_json = super(Table, self).gen_json_from_data(data, context)
@@ -176,6 +176,8 @@ class Table(PanelsItemBase):
 
 
 class Text(PanelsItemBase):
+    _copy_fields = {'description'}
+
     def gen_json_from_data(self, data, context):
         panel_json = super(Text, self).gen_json_from_data(data, context)
         panel_json.update({
@@ -189,7 +191,7 @@ class Text(PanelsItemBase):
 
 
 class Dashlist(PanelsItemBase):
-    _copy_fields = {'headings', 'limit', 'recent', 'tags', 'query'}
+    _copy_fields = {'headings', 'limit', 'recent', 'tags', 'query', 'description'}
 
     def gen_json_from_data(self, data, context):
         panel_json = super(Dashlist, self).gen_json_from_data(data, context)

--- a/grafana_dashboards/components/targets.py
+++ b/grafana_dashboards/components/targets.py
@@ -55,7 +55,7 @@ class GraphiteTarget(TargetsItemBase):
 
 
 class PrometheusTarget(TargetsItemBase):
-    _copy_fields = {'format', 'hide', 'intervalFactor', 'legendFormat', 'step'}
+    _copy_fields = {'format', 'hide', 'intervalFactor', 'legendFormat', 'step', 'instant', 'interval'}
 
     def gen_json_from_data(self, data, context):
         template_json = super(PrometheusTarget, self).gen_json_from_data(data, context)
@@ -71,4 +71,13 @@ class InfluxdbTarget(TargetsItemBase):
         template_json['query'] = data['query']
         template_json['dsType'] = 'influxdb'
         template_json['rawQuery'] = True
+        return template_json
+
+
+class ElasticTarget(TargetsItemBase):
+    _copy_fields = {'bucketAggs', 'hide', 'metrics', 'refId', 'timeField'}
+
+    def gen_json_from_data(self, data, context):
+        template_json = super(ElasticTarget, self).gen_json_from_data(data, context)
+        template_json['query'] = data['query']
         return template_json

--- a/grafana_dashboards/components/templates.py
+++ b/grafana_dashboards/components/templates.py
@@ -50,6 +50,8 @@ class Query(TemplatesItemBase):
                 template_json['refresh'] = 1
             if 'datasource' in data:
                 template_json['datasource'] = data['datasource']
+            if 'sort' in data:
+                template_json['sort'] = data['sort']
             self._copy_data(template_json, data)
             queries.append(template_json)
         else:

--- a/grafana_dashboards/config.py
+++ b/grafana_dashboards/config.py
@@ -34,7 +34,7 @@ class Config(object):
             self._config = {}
         else:
             with open(config) as fp:
-                self._config = yaml.load(fp)
+                self._config = yaml.load(fp, Loader=yaml.FullLoader)
 
     def get_config(self, section):
         return self._config.setdefault(section, {})

--- a/grafana_dashboards/parser.py
+++ b/grafana_dashboards/parser.py
@@ -30,7 +30,7 @@ class DefinitionParser(object):
         registry = ComponentRegistry()
         for path in paths:
             with open(path, 'r') as fp:
-                for component in self._iter_over_all(yaml.load_all(fp)):
+                for component in self._iter_over_all(yaml.load_all(fp, Loader=yaml.FullLoader)):
                     registry.add(component)
         return registry[Project]
 

--- a/samples/config.yaml
+++ b/samples/config.yaml
@@ -3,7 +3,7 @@ elastic-search:
   password: my_password
   username: my_username
 grafana:
-  host: http://localhost:8380
+  host: http://localhost:3000
   username: admin
   password: admin
 file:

--- a/samples/elastic.yaml
+++ b/samples/elastic.yaml
@@ -1,0 +1,51 @@
+---
+- name: Example Elastic project
+  project:
+    dashboards:
+    - elastic-overview
+
+- default-dashboard: &default-dashboard
+    time_options: [1h, 6h, 12h, 24h, 2d, 7d, 14d, 30d]
+    refresh_intervals: [5m, 15m, 30m, 1h]
+    time:
+      from: now-2d
+      to: now
+
+- name: elastic-overview
+  dashboard:
+    title: elastic Overview
+    tags:
+    - tag1
+    <<: *default-dashboard
+    templates:
+    - datasource-template:
+        query: elastic
+    sharedCrosshair: true
+    rows:
+    - row:
+        panels:
+        - graph:
+            title: "Elastic"
+            datasource: $datasource
+            yaxes:
+            - yaxis:
+                label: Milicores
+            - yaxis:
+            targets:
+            - elastic-target:
+                query: '(status: "succeeded")'
+                bucketAggs:
+                - field: finishedAt
+                  type: date_histogram
+                  id: "2"
+                  settings:
+                    interval: 'auto'
+                    min_doc_count: 1
+                    trimEdges: 0
+                hide: false
+                metrics: 
+                - field: "select metric"
+                  id: "1"
+                  type: count                
+                refId: "A"
+                timeField: finishedAt

--- a/samples/prometheus.yaml
+++ b/samples/prometheus.yaml
@@ -24,10 +24,12 @@
         datasource: $datasource
         name: namespace
         query: label_values(kube_namespace_labels, namespace)
+        sort: 0
     - query:
         datasource: $datasource
         name: pod
         query: label_values(kube_pod_labels{namespace="$namespace"},pod)
+        sort: 1
     - interval-template:
         name: interval
         current: auto

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ class Tox(TestCommand):
 
 params = {
     'name': 'grafana-dashboard-builder',
-    'version': '0.5.0a2',
+    'version': '0.6.0a1',
     'packages': [
         'grafana_dashboards',
         'grafana_dashboards.client',

--- a/tests/grafana_dashboards/components/dashlist/full.json
+++ b/tests/grafana_dashboards/components/dashlist/full.json
@@ -7,5 +7,6 @@
   "search": true,
   "starred": true,
   "recent": true,
-  "limit": 20
+  "limit": 20,
+  "description": "description"
 }

--- a/tests/grafana_dashboards/components/dashlist/full.yaml
+++ b/tests/grafana_dashboards/components/dashlist/full.yaml
@@ -9,3 +9,4 @@ dashlist:
   starred: true
   heading: true
   limit: 20
+  description: description

--- a/tests/grafana_dashboards/components/elastic-target/defaults.json
+++ b/tests/grafana_dashboards/components/elastic-target/defaults.json
@@ -1,0 +1,3 @@
+{
+  "query": "(status: 'succeeded')"
+}

--- a/tests/grafana_dashboards/components/elastic-target/defaults.yaml
+++ b/tests/grafana_dashboards/components/elastic-target/defaults.yaml
@@ -1,0 +1,2 @@
+elastic-target:
+  query: "(status: 'succeeded')"

--- a/tests/grafana_dashboards/components/elastic-target/full.json
+++ b/tests/grafana_dashboards/components/elastic-target/full.json
@@ -1,0 +1,25 @@
+{
+  "query": "(status: 'succeeded')",
+  "bucketAggs": [
+    {
+      "field": "finishedAt",
+      "id": "2",
+      "settings": {
+        "interval": "auto",
+        "min_doc_count": 1,
+        "trimEdges": 0
+      },
+      "type": "date_histogram"
+    }
+  ],
+  "hide": false,
+  "metrics": [
+    {
+      "field": "select metric",
+      "id": "1",
+      "type": "count"
+    }
+  ],
+  "refId": "A",
+  "timeField": "finishedAt"
+}

--- a/tests/grafana_dashboards/components/elastic-target/full.yaml
+++ b/tests/grafana_dashboards/components/elastic-target/full.yaml
@@ -1,0 +1,17 @@
+elastic-target:
+  query: "(status: 'succeeded')"
+  bucketAggs:
+  - field: finishedAt
+    type: date_histogram
+    id: "2"
+    settings:
+      interval: 'auto'
+      min_doc_count: 1
+      trimEdges: 0
+  hide: false
+  metrics: 
+  - field: "select metric"
+    id: "1"
+    type: count                
+  refId: "A"
+  timeField: finishedAt

--- a/tests/grafana_dashboards/components/graph/full.json
+++ b/tests/grafana_dashboards/components/graph/full.json
@@ -38,6 +38,7 @@
   "y-axis": false,
   "yaxes": ["mocked <class 'grafana_dashboards.components.axes.Yaxes'>"],
   "xaxis": {"mode": "time", "show": true},
+  "decimals": 2,
   "legend": {
     "avg": true,
     "current": true,
@@ -47,6 +48,7 @@
     "total": true,
     "values": true,
     "alignAsTable": true,
+    "rightSide": true,
     "hideEmpty": true
   },
   "tooltip": {
@@ -66,5 +68,7 @@
   ],
   "minSpan": 3,
   "repeat": "node",
-  "datasource": "datasource"
+  "repeatDirection": "v",
+  "datasource": "datasource",
+  "description": "description"
 }

--- a/tests/grafana_dashboards/components/graph/full.yaml
+++ b/tests/grafana_dashboards/components/graph/full.yaml
@@ -39,6 +39,7 @@ graph:
   aliasColors:
     alias1: '#000000'
   leftYAxisLabel: axis label
+  decimals: 2
   legend:
     show: false
     values: true
@@ -48,6 +49,7 @@ graph:
     total: true
     avg: true
     alignAsTable: true
+    rightSide: true
     hideEmpty: true
   tooltip:
     value_type: cumulative
@@ -60,4 +62,6 @@ graph:
         points: true
   minSpan: 3
   repeat: node
+  repeatDirection: v
   datasource: datasource
+  description: description

--- a/tests/grafana_dashboards/components/prometheus-target/full.json
+++ b/tests/grafana_dashboards/components/prometheus-target/full.json
@@ -2,6 +2,8 @@
   "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod_name=~\"$pod\"}[$interval])) by (container_name) * 1000",
   "format": "table",
   "hide": true,
+  "instant": true,
+  "interval": "5d",
   "intervalFactor": 10,
   "legendFormat": "Usage",
   "step": 60

--- a/tests/grafana_dashboards/components/prometheus-target/full.yaml
+++ b/tests/grafana_dashboards/components/prometheus-target/full.yaml
@@ -2,6 +2,8 @@ prometheus-target:
   expr: "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod_name=~\"$pod\"}[$interval])) by (container_name) * 1000"
   format: table
   hide: true
+  instant: true
+  interval: '5d'
   intervalFactor: 10
   legendFormat: 'Usage'
   step: 60

--- a/tests/grafana_dashboards/components/query/full_singlequery.json
+++ b/tests/grafana_dashboards/components/query/full_singlequery.json
@@ -24,7 +24,8 @@
     "includeAll": true,
     "allFormat": "glob",
     "allValue": "test*",
-    "hide": 2
+    "hide": 2,
+    "sort": 1
   }
 ]
 

--- a/tests/grafana_dashboards/components/query/full_singlequery.yaml
+++ b/tests/grafana_dashboards/components/query/full_singlequery.yaml
@@ -12,3 +12,4 @@ query:
   allValue: test*
   multi: true
   hide: 2
+  sort: 1

--- a/tests/grafana_dashboards/components/single-stat/full.json
+++ b/tests/grafana_dashboards/components/single-stat/full.json
@@ -2,7 +2,7 @@
   "span": 3,
   "title": "test title",
   "type": "singlestat",
-  "valueName": "current",
+  "valueName": "value-name",
   "nullPointMode": "connected",
   "targets": ["mocked <class 'grafana_dashboards.components.targets.Targets'>"],
   "links": [
@@ -37,6 +37,7 @@
   ],
   "datasource": "datasource",
   "repeat": "var",
+  "repeatDirection": "v",
   "decimals": 1,
   "minSpan": 2,
   "gauge" : {
@@ -45,5 +46,7 @@
     "maxValue": 2,
     "thresholdMarkers": false,
     "thresholdLabels": true
-  }
+  },
+  "description": "description",
+  "colorPostfix": true
 }

--- a/tests/grafana_dashboards/components/single-stat/full.yaml
+++ b/tests/grafana_dashboards/components/single-stat/full.yaml
@@ -30,6 +30,7 @@ single-stat:
   maxDataPoints: 100
   datasource: datasource
   repeat: var
+  repeatDirection: v
   decimals: 1
   minSpan: 2
   gauge:
@@ -38,4 +39,7 @@ single-stat:
     maxValue: 2
     thresholdMarkers: false
     thresholdLabels: true
+  description: description
+  colorPostfix: true
+  valueName: value-name
 

--- a/tests/grafana_dashboards/components/table/row_color_mode.json
+++ b/tests/grafana_dashboards/components/table/row_color_mode.json
@@ -32,5 +32,6 @@
   "title": "Row color mode",
   "transform": "timeseries_to_columns",
   "type": "table",
-  "datasource": "datasource"
+  "datasource": "datasource",
+  "description": "description"
 }

--- a/tests/grafana_dashboards/components/table/row_color_mode.yaml
+++ b/tests/grafana_dashboards/components/table/row_color_mode.yaml
@@ -25,3 +25,4 @@ table:
         thresholds:
           - ' 200'
           - ' 250'
+  description: description

--- a/tests/grafana_dashboards/components/table/time_series_aggregations.json
+++ b/tests/grafana_dashboards/components/table/time_series_aggregations.json
@@ -44,5 +44,6 @@
   "title": "Time series aggregations",
   "transform": "timeseries_aggregations",
   "type": "table",
-  "datasource": "datasource"
+  "datasource": "datasource",
+  "description": "description"
 }

--- a/tests/grafana_dashboards/components/table/time_series_aggregations.yaml
+++ b/tests/grafana_dashboards/components/table/time_series_aggregations.yaml
@@ -28,3 +28,4 @@ table:
         thresholds:
           - '270'
           - '275'
+  description: description

--- a/tests/grafana_dashboards/components/test_components.py
+++ b/tests/grafana_dashboards/components/test_components.py
@@ -49,7 +49,7 @@ def load_test_fixtures():
                 continue
             filename = f[:-5]
             with open(os.path.join(dirname, '%s.yaml' % filename), 'r') as fp:
-                config = yaml.load(fp)
+                config = yaml.load(fp, Loader=yaml.FullLoader)
             with open(os.path.join(dirname, '%s.json' % filename), 'r') as fp:
                 output = json.load(fp)
             yield component, filename, config, output

--- a/tests/grafana_dashboards/components/text/full.json
+++ b/tests/grafana_dashboards/components/text/full.json
@@ -3,5 +3,6 @@
   "title": "test title",
   "mode": "text",
   "content": "this is\nmultiline\ntext\n",
-  "type": "text"
+  "type": "text",
+  "description": "description"
 }

--- a/tests/grafana_dashboards/components/text/full.yaml
+++ b/tests/grafana_dashboards/components/text/full.yaml
@@ -6,3 +6,4 @@ text:
     this is
     multiline
     text
+  description: description


### PR DESCRIPTION
This PR enable support for "sort" field on query template variables. Now is possible to specify the order of items coming out from a query template variable (https://grafana.com/docs/reference/templating/#variable-types)