### PR TITLE
FEATURE: Add SSL client cert auth

### DIFF
--- a/grafana_dashboards/client/connection.py
+++ b/grafana_dashboards/client/connection.py
@@ -108,3 +108,14 @@ class KerberosConnection(object):
     def make_request(self, uri, body=None):
         response = requests.post('{0}{1}'.format(self._host, uri), json=body, auth=HTTPKerberosAuth(), verify=False)
         return response.json()
+
+
+class SSLAuthConnection(object):
+    def __init__(self, host, cert_bundle, debug=0):
+        logger.debug('Using SSL client cert from "%s" with host=%s', cert_bundle, host)
+        self._host = host
+        self._cert = cert_bundle
+
+    def make_request(self, uri, body=None):
+        response = requests.post('{0}{1}'.format(self._host, uri), json=body, cert=self._cert)
+        return response.json()

--- a/tests/grafana_dashboards/client/test_connection.py
+++ b/tests/grafana_dashboards/client/test_connection.py
@@ -20,7 +20,10 @@ except ImportError:
 from mock import MagicMock, patch
 from requests_kerberos import HTTPKerberosAuth
 
-from grafana_dashboards.client.connection import KerberosConnection, BasicAuthConnection, BearerAuthConnection
+from grafana_dashboards.client.connection import (KerberosConnection,
+                                                  BearerAuthConnection,
+                                                  BasicAuthConnection,
+                                                  SSLAuthConnection)
 
 __author__ = 'Jakub Plichta <jakub.plichta@gmail.com>'
 
@@ -98,3 +101,14 @@ def test_connection_with_kerberos(post):
     capture = Capture()
     post.assert_called_with('https://host/uri', auth=capture, json={"it's": 'alive'}, verify=False)
     assert isinstance(capture.value, HTTPKerberosAuth)
+
+
+@patch('requests.post')
+def test_connection_with_sslauth(post):
+    connection = SSLAuthConnection('https://host', ('/fake/cert'))
+
+    post().json.return_value = {'hello': 'world'}
+
+    assert connection.make_request('/uri', {'it\'s': 'alive'}) == {'hello': 'world'}
+
+    post.assert_called_with('https://host/uri', json={"it's": 'alive'}, cert='/fake/cert')

--- a/tests/grafana_dashboards/client/test_grafana.py
+++ b/tests/grafana_dashboards/client/test_grafana.py
@@ -45,3 +45,16 @@ def test_grafana_with_kerberos():
     # noinspection PyProtectedMember
     exporter._connection.make_request.assert_called_once_with('/api/dashboards/db',
                                                               body)
+
+
+def test_grafana_with_sslauth():
+    exporter = GrafanaExporter(host='host', ssl_client_crt='/file/fake')
+    exporter._connection = MagicMock()
+
+    dashboard_data = {'title': 'title', 'tags': []}
+    exporter.process_dashboard('project_name', 'dashboard_name', dashboard_data)
+
+    body = {'overwrite': True, 'dashboard': dashboard_data}
+    # noinspection PyProtectedMember
+    exporter._connection.make_request.assert_called_once_with('/api/dashboards/db',
+                                                              body)


### PR DESCRIPTION
Allow for SSL client certificate to be used for authentication
when GRAFANA_SSL_CLIENT_CRT (+ optionally GRAFANA_SSL_CLIENT_KEY)
environment variables are set.