### PR TITLE
Python 3.12 compatibility

### DIFF
--- a/grafana_dashboards/cli.py
+++ b/grafana_dashboards/cli.py
@@ -17,7 +17,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import argparse
-import imp
 import logging
 import os
 
@@ -25,7 +24,7 @@ import yaml
 
 from grafana_dashboards.client.elastic_search import ElasticSearchExporter
 from grafana_dashboards.client.grafana import GrafanaExporter
-from grafana_dashboards.common import get_component_type
+from grafana_dashboards.common import get_component_type, load_source
 from grafana_dashboards.config import Config
 from grafana_dashboards.exporter import ProjectProcessor, FileExporter
 from grafana_dashboards.parser import DefinitionParser
@@ -75,7 +74,7 @@ def main():
     if args.plugins:
         for plugin in args.plugins:
             try:
-                imp.load_source('grafana_dashboards.components.$loaded', plugin)
+                load_source('grafana_dashboards.components.$loaded', plugin)
             except Exception as e:
                 print('Cannot load plugin %s: %s' % (plugin, str(e)))
 

--- a/grafana_dashboards/common.py
+++ b/grafana_dashboards/common.py
@@ -14,7 +14,10 @@
 # limitations under the License.
 from __future__ import unicode_literals
 
+import importlib.machinery
+import importlib.util
 import re
+import sys
 
 __author__ = 'Jakub Plichta <jakub.plichta@gmail.com>'
 
@@ -29,3 +32,15 @@ def get_component_type(clazz):
     :type clazz: type
     """
     return _all_cap_re.sub(r'\1-\2', _first_cap_re.sub(r'\1-\2', clazz.__name__)).lower()
+
+
+if sys.version_info >= (3, 12):
+    def load_source(modname, filename):
+        loader = importlib.machinery.SourceFileLoader(modname, filename)
+        spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+        module = importlib.util.module_from_spec(spec)
+
+        loader.exec_module(module)
+        return module
+else:
+    from imp import load_source

--- a/grafana_dashboards/common.py
+++ b/grafana_dashboards/common.py
@@ -35,6 +35,8 @@ def get_component_type(clazz):
 
 
 if sys.version_info >= (3, 12):
+    # Replacement to imp.load_source suggested on the python 3.12 changelog:
+    # https://docs.python.org/3/whatsnew/3.12.html#imp
     def load_source(modname, filename):
         loader = importlib.machinery.SourceFileLoader(modname, filename)
         spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8, py{37,38,39,310,311}
+envlist = pep8, py{37,38,39,310,311,312}
 
 [gh-actions]
 python =
@@ -8,6 +8,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [coverage:run]
 relative_files = True


### PR DESCRIPTION
Just replaced the use of the removed `imp` module with the replacement provided in [python 3.12 changelog](https://docs.python.org/3/whatsnew/3.12.html#imp) keeping the behavior intact for previous python versions.

Feel free to request any changes